### PR TITLE
Add AI Models Catalog to Other Resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -311,7 +311,8 @@ A taxonomy of post-training approaches for **LLMs**, categorized into Fine-tunin
 ## 🔗 Other Resources  
 
 - [LLM for RL Workshop at NeurIPS 2023](https://neurips.cc)  
-- [OpenAI Research Blog on RLHF](https://openai.com/research)  
+- [OpenAI Research Blog on RLHF](https://openai.com/research)
+- [AI Models Catalog](https://github.com/i-need-token/ai-models) — Structured YAML catalog of 4,587+ AI models with 1,306 reasoning models, pricing, context windows, and capabilities  
 
 ---
 


### PR DESCRIPTION
Hi! I'd like to add the [AI Models Catalog](https://github.com/i-need-token/ai-models) to the Other Resources section.

**What it is:** A structured YAML catalog of 4,587+ AI models across 95 providers, with first-party data on pricing, context windows, modalities, and capabilities. It includes **1,306 reasoning models** with detailed metadata.

**Why it's useful for post-training researchers:** When researching post-training methods, practitioners need to understand the landscape of available models and their capabilities. The catalog provides:
- Compare reasoning models by pricing and capabilities
- Filter by reasoning + tool calling + structured output combinations
- [Interactive comparison page for reasoning models](https://i-need-token.github.io/ai-models/reasoning-models-comparison.html)
- Data available as JSON, CSV, npm package, and GitHub Action

All data sourced from first-party APIs, validated with Zod schemas, updated automatically via CI.

Thanks for considering!