### PR TITLE
Add AudioRubrics (arXiv 2608.02831) to Reward Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A taxonomy of post-training approaches for **LLMs**, categorized into Fine-tunin
 
 ## 🏆 Reward Learning (Process Reward Models)
 
+* Reinforcement Learning with Evolving Rubrics as Rewards for Audio Reasoning [[Paper]](https://arxiv.org/abs/2608.02831) ![](https://img.shields.io/badge/arXiv-2026.08-red)
 * PRMBench: A Fine-grained and Challenging Benchmark for Process-Level Reward Models. [[Paper]](https://arxiv.org/abs/2501.03124) ![](https://img.shields.io/badge/arXiv-2025.01-red)
 * ReARTeR: Retrieval-Augmented Reasoning with Trustworthy Process Rewarding [[Paper]](https://arxiv.org/abs/2501.07861) ![](https://img.shields.io/badge/arXiv-2025.01-red)
 * The Lessons of Developing Process Reward Models in Mathematical Reasoning. [[Paper]](https://arxiv.org/abs/2501.07301) ![](https://img.shields.io/badge/arXiv-2025.01-red)


### PR DESCRIPTION
Thanks for maintaining this list! I would like to add our recent paper to the **🏆 Reward Learning** section.

**[Reinforcement Learning with Evolving Rubrics as Rewards for Audio Reasoning](https://arxiv.org/abs/2608.02831)** (arXiv 2026.08)
Fangxu Yu, Tao Feng, Dehai Min, Zinan Lin, Weijia Xu, Michael Xu, Philip S. Yu, Ge Liu, Tianyi Zhou
Project page: https://audiorubrics.github.io

The paper addresses reward design for post-training on tasks without verifiable answers. Instead of a fixed reward model or static criteria, it synthesizes question-specific rubrics from raw audio and evolves them during training based on model performance, producing a continuous learning signal. Results on three benchmarks show gains over existing reward designs, scaling with the capability of the rubric generator and evaluator.

I placed it under Reward Learning since the contribution is the reward formulation rather than the policy optimizer, but happy to move it to **LLMs-in-RL** if you prefer. Single-line addition matching the existing entry format and arXiv badge style.