### PR TITLE
Add RewardHarness to Reward Learning

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,7 @@ A taxonomy of post-training approaches for **LLMs**, categorized into Fine-tunin
 
 ## 🏆 Reward Learning (Process Reward Models)
 
+* RewardHarness: Self-Evolving Agentic Post-Training [[Paper]](https://arxiv.org/abs/2605.08703) ![](https://img.shields.io/badge/arXiv-2026.05-red) [[Code]](https://github.com/KlingAIResearch/RewardHarness)
 * PRMBench: A Fine-grained and Challenging Benchmark for Process-Level Reward Models. [[Paper]](https://arxiv.org/abs/2501.03124) ![](https://img.shields.io/badge/arXiv-2025.01-red)
 * ReARTeR: Retrieval-Augmented Reasoning with Trustworthy Process Rewarding [[Paper]](https://arxiv.org/abs/2501.07861) ![](https://img.shields.io/badge/arXiv-2025.01-red)
 * The Lessons of Developing Process Reward Models in Mathematical Reasoning. [[Paper]](https://arxiv.org/abs/2501.07301) ![](https://img.shields.io/badge/arXiv-2025.01-red)


### PR DESCRIPTION
## Summary

Add RewardHarness, a self-evolving agentic reward framework for image-editing preference evaluation, to the Reward Learning section.

## Relevance

RewardHarness evolves an inference-time skills and tools library from roughly 100 preference demonstrations, then uses a frozen vision-language sub-agent to produce preference judgments. Its scalar output can also serve as a GRPO reward signal.

I checked the README and existing pull requests and found no RewardHarness entry.