### PR TITLE
Add HAT: training agents to adapt to evolving harnesses

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,8 @@ A taxonomy of post-training approaches for **LLMs**, categorized into Fine-tunin
 
 ## 🤖 LLMs-in-RL  
 
+* Training Agents to Evolve with Their Harness: TaoLive Digital Avatar Agent Technical Report [[Paper]](https://arxiv.org/abs/2608.15763) ![](https://img.shields.io/badge/arXiv-2026.08-red)
+
 * Vision-Zero: Scalable VLM Self-Improvement via Strategic Gamified Self-Play [[Paper]](https://www.arxiv.org/abs/2509.25541) ![](https://img.shields.io/badge/arXiv-2025.09-red)
 * Satori: Reinforcement Learning with Chain-of-Action-Thought Enhances LLM Reasoning via Autoregressive Search [[Paper]](https://arxiv.org/abs/2502.02508) ![](https://img.shields.io/badge/arXiv-2025.02-red)
 * DeepScaleR: Surpassing O1-Preview with a 1.5B Model by Scaling RL [[Paper]](https://pretty-radio-b75.notion.site/DeepScaleR-Surpassing-O1-Preview-with-a-1-5B-Model-by-Scaling-RL-19681902c1468005bed8ca303013a4e2) ![](https://img.shields.io/badge/Notion-2025.02-red)


### PR DESCRIPTION
Thank you for bringing the different post-training approaches into one reading list. The separation of policy optimization, reward learning, and applications is especially helpful.

I'm Yuhan Sun, one of the authors of [Training Agents to Evolve with Their Harness: TaoLive Digital Avatar Agent Technical Report](https://arxiv.org/abs/2608.15763).

HAT is an application of post-training to an agent whose runtime keeps changing. Its pipeline combines harness-augmented SFT, general on-policy distillation to recover instruction following, and GRPO in a simulator with varied harness states. I added the report to LLMs-in-RL as an agent-training example.

Thank you for considering the addition.
